### PR TITLE
BF--I5/esp32c3_support_custom_mac

### DIFF
--- a/components/efuse/esp32c3/esp_efuse_table.c
+++ b/components/efuse/esp32c3/esp_efuse_table.c
@@ -17,7 +17,7 @@
 #include <assert.h>
 #include "esp_efuse_table.h"
 
-// md5_digest_table f9a84eb22f94a7bc083b4c6817a33a59
+// md5_digest_table 196aac9fbce9004685fa9a7d2b79fc17
 // This file was generated from the file esp_efuse_table.csv. DO NOT CHANGE THIS FILE MANUALLY.
 // If you want to change some fields, you need to change esp_efuse_table.csv file
 // then run `efuse_common_table` or `efuse_custom_table` command it will generate this file.
@@ -453,7 +453,11 @@ static const esp_efuse_desc_t ADC1_CAL_VOL_ATTEN3[] = {
 };
 
 static const esp_efuse_desc_t USER_DATA[] = {
-    {EFUSE_BLK3, 0, 256}, 	 // User data,
+    {EFUSE_BLK3, 0, 200}, 	 // User data,
+};
+
+static const esp_efuse_desc_t USER_DATA_MAC_CUSTOM[] = {
+    {EFUSE_BLK3, 200, 48}, 	 // Custom MAC,
 };
 
 static const esp_efuse_desc_t KEY0[] = {
@@ -1025,6 +1029,11 @@ const esp_efuse_desc_t* ESP_EFUSE_ADC1_CAL_VOL_ATTEN3[] = {
 
 const esp_efuse_desc_t* ESP_EFUSE_USER_DATA[] = {
     &USER_DATA[0],    		// User data
+    NULL
+};
+
+const esp_efuse_desc_t* ESP_EFUSE_USER_DATA_MAC_CUSTOM[] = {
+    &USER_DATA_MAC_CUSTOM[0],    		// Custom MAC
     NULL
 };
 

--- a/components/efuse/esp32c3/esp_efuse_table.csv
+++ b/components/efuse/esp32c3/esp_efuse_table.csv
@@ -145,7 +145,10 @@
     ADC1_CAL_VOL_ATTEN3,                  EFUSE_BLK2,  218,   10,     ADC1 calibration voltage at atten3
 
 ################
-USER_DATA,                                EFUSE_BLK3,    0,  256,     User data
+USER_DATA,                                EFUSE_BLK3,    0,  200,     User data
+USER_DATA_MAC_CUSTOM,                     EFUSE_BLK3,  200,   48,     Custom MAC
+
+################
 KEY0,                                     EFUSE_BLK4,    0,  256,     Key0 or user data
 KEY1,                                     EFUSE_BLK5,    0,  256,     Key1 or user data
 KEY2,                                     EFUSE_BLK6,    0,  256,     Key2 or user data

--- a/components/efuse/esp32c3/include/esp_efuse_table.h
+++ b/components/efuse/esp32c3/include/esp_efuse_table.h
@@ -17,7 +17,7 @@ extern "C" {
 #endif
 
 
-// md5_digest_table f9a84eb22f94a7bc083b4c6817a33a59
+// md5_digest_table 196aac9fbce9004685fa9a7d2b79fc17
 // This file was generated from the file esp_efuse_table.csv. DO NOT CHANGE THIS FILE MANUALLY.
 // If you want to change some fields, you need to change esp_efuse_table.csv file
 // then run `efuse_common_table` or `efuse_custom_table` command it will generate this file.
@@ -131,6 +131,7 @@ extern const esp_efuse_desc_t* ESP_EFUSE_ADC1_CAL_VOL_ATTEN1[];
 extern const esp_efuse_desc_t* ESP_EFUSE_ADC1_CAL_VOL_ATTEN2[];
 extern const esp_efuse_desc_t* ESP_EFUSE_ADC1_CAL_VOL_ATTEN3[];
 extern const esp_efuse_desc_t* ESP_EFUSE_USER_DATA[];
+extern const esp_efuse_desc_t* ESP_EFUSE_USER_DATA_MAC_CUSTOM[];
 extern const esp_efuse_desc_t* ESP_EFUSE_KEY0[];
 extern const esp_efuse_desc_t* ESP_EFUSE_KEY1[];
 extern const esp_efuse_desc_t* ESP_EFUSE_KEY2[];


### PR DESCRIPTION
- 新增CUSTOM_MAC的欄位到efuse table (ESP32C3)
- 從efuse table取得CUSTOM_MAC (ESP32C3)
- reference: https://github.com/espressif/esp-idf/commit/40c360a09637fb8bce20fc3c29e8d16163db8e3c#