### PR TITLE
skip_mac_crc_check_fail

### DIFF
--- a/components/esp_common/Kconfig
+++ b/components/esp_common/Kconfig
@@ -304,6 +304,16 @@ menu "Common ESP-related"
     config ESP_MAC_ADDR_UNIVERSE_ETH
         bool
 
+    config ESP_MAC_IGNORE_MAC_CRC_ERROR
+        bool "Ignore MAC CRC error (not recommended)"
+        depends on IDF_TARGET_ESP32
+        default n
+        help
+            If you have an invalid MAC CRC (ESP_ERR_INVALID_CRC) problem
+            and you still want to use this chip, you can enable this option to bypass such an error.
+            This applies to both MAC_FACTORY and CUSTOM_MAC efuses.
+    
+
     config ESP_ALLOW_BSS_SEG_EXTERNAL_MEMORY
         # Invisible option that is set by SPIRAM_ALLOW_BSS_SEG_EXTERNAL_MEMORY, but
         # exists even if SPIRAM is not supported

--- a/components/esp_common/src/mac_addr.c
+++ b/components/esp_common/src/mac_addr.c
@@ -90,7 +90,11 @@ esp_err_t esp_efuse_mac_get_custom(uint8_t *mac)
 
     if (efuse_crc != calc_crc) {
         ESP_LOGE(TAG, "Base MAC address from BLK3 of EFUSE CRC error, efuse_crc = 0x%02x; calc_crc = 0x%02x", efuse_crc, calc_crc);
+#ifdef CONFIG_ESP_MAC_IGNORE_MAC_CRC_ERROR
+        ESP_LOGW(TAG, "Ignore MAC CRC error");
+#else
         return ESP_ERR_INVALID_CRC;
+#endif
     }
     return ESP_OK;
 #endif
@@ -117,7 +121,11 @@ esp_err_t esp_efuse_mac_get_default(uint8_t* mac)
             return ESP_OK;
         } else {
             ESP_LOGE(TAG, "Base MAC address from BLK0 of EFUSE CRC error, efuse_crc = 0x%02x; calc_crc = 0x%02x", efuse_crc, calc_crc);
-            abort();
+#ifdef CONFIG_ESP_MAC_IGNORE_MAC_CRC_ERROR
+            ESP_LOGW(TAG, "Ignore MAC CRC error");
+#else
+            return ESP_ERR_INVALID_CRC;
+#endif
         }
     }
 #endif // CONFIG_IDF_TARGET_ESP32

--- a/components/esp_wifi/src/phy_init.c
+++ b/components/esp_wifi/src/phy_init.c
@@ -498,7 +498,7 @@ static esp_err_t load_cal_data_from_nvs_handle(nvs_handle_t handle,
         return ESP_ERR_INVALID_SIZE;
     }
     uint8_t sta_mac[6];
-    esp_efuse_mac_get_default(sta_mac);
+    ESP_ERROR_CHECK(esp_efuse_mac_get_default(sta_mac));
     if (memcmp(sta_mac, cal_data_mac, sizeof(sta_mac)) != 0) {
         ESP_LOGE(TAG, "%s: calibration data MAC check failed: expected " \
                 MACSTR ", found " MACSTR,
@@ -530,7 +530,7 @@ static esp_err_t store_cal_data_to_nvs_handle(nvs_handle_t handle,
     }
 
     uint8_t sta_mac[6];
-    esp_efuse_mac_get_default(sta_mac);
+    ESP_ERROR_CHECK(esp_efuse_mac_get_default(sta_mac));
     err = nvs_set_blob(handle, PHY_CAL_MAC_KEY, sta_mac, sizeof(sta_mac));
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "%s: store calibration mac failed(0x%x)\n", __func__, err);
@@ -618,7 +618,7 @@ void esp_phy_load_cal_and_init(void)
         calibration_mode = PHY_RF_CAL_FULL;
     }
 
-    esp_efuse_mac_get_default(sta_mac);
+    ESP_ERROR_CHECK(esp_efuse_mac_get_default(sta_mac));
     memcpy(cal_data->mac, sta_mac, 6);
     esp_err_t ret = register_chipv7_phy(init_data, cal_data, calibration_mode);
     if (ret == ESP_CAL_DATA_CHECK_FAIL) {


### PR DESCRIPTION
- 處理非正式晶片的MAC CRC有誤造成無法開機的問題
- 修改參考: https://github.com/espressif/esp-idf/commit/7a23bf19be80d4f9b711340f294711f9c527a402