### PR TITLE
fix_mbedtls_issue

### DIFF
--- a/components/esp_http_server/src/httpd_parse.c
+++ b/components/esp_http_server/src/httpd_parse.c
@@ -810,7 +810,7 @@ esp_err_t httpd_req_delete(struct httpd_data *hd)
         char dummy[CONFIG_HTTPD_PURGE_BUF_LEN];
         int recv_len = MIN(sizeof(dummy), ra->remaining_len);
         recv_len = httpd_req_recv(r, dummy, recv_len);
-        if (recv_len < 0) {
+        if (recv_len <= 0) {
             httpd_req_cleanup(r);
             return ESP_FAIL;
         }

--- a/components/protocomm/src/transports/protocomm_httpd.c
+++ b/components/protocomm/src/transports/protocomm_httpd.c
@@ -136,7 +136,7 @@ static esp_err_t common_post_handler(httpd_req_t *req)
     size_t recv_size = 0;
     while (recv_size < req->content_len) {
         ret = httpd_req_recv(req, req_body + recv_size, req->content_len - recv_size);
-        if (ret < 0) {
+        if (ret <= 0) {
             ret = ESP_FAIL;
             goto out;
         }


### PR DESCRIPTION
長時間擺放會出現log Dynamic Impl: mbedtls_ssl_fetch_input error=29312
error code代表的是MBEDTLS_ERR_SSL_CONN_EOF, 參照esp-idf的修正commit
https://github.com/espressif/esp-idf/commit/ba15970abbec43ff54c843ad859ad159a36d3a01